### PR TITLE
fixes incorrect url in advertisement tile

### DIFF
--- a/fachschaftsempfaenger/templates/tiles/advertisement.html
+++ b/fachschaftsempfaenger/templates/tiles/advertisement.html
@@ -6,7 +6,7 @@
   <i class="fa fa-exclamation-circle"></i>Obacht!
 </div>
     {% if advertisement.image %}
-        <div id="ad-image" style="background-image: url({{ ad.image.url }})">
+        <div id="ad-image" style="background-image: url({{ advertisement.image.url }})">
         </div>
     {% endif %}
     {% comment "not needed right now" %}


### PR DESCRIPTION
I've done a whoopsie. In the process of renaming Ad to Advertisement, I forgot one URL in the template for `advertisement.html`. Thanks, PyCharm...