### PR TITLE
fixes display of advertisement messages (#34)

### DIFF
--- a/fachschaftsempfaenger/views.py
+++ b/fachschaftsempfaenger/views.py
@@ -121,8 +121,13 @@ def advertisement_tile(request):
     """
     # Are there any messages to be displayed right now? If there are, select one at random.
     # Note that this query is quite expensive and could potentially slow the load time of this tile down.
-    if Advertisement.objects.filter(start_date__gte=timezone.now()):
-        qs = Advertisement.objects.filter(start_date__gte=timezone.now()).order_by('?').first()
+    if Advertisement.objects.filter(
+            start_date__lte=timezone.now(),
+            end_date__gte=timezone.now()
+    ):
+        qs = Advertisement.objects.filter(
+            start_date__lte=timezone.now(),
+            end_date__gte=timezone.now()).order_by('?').first()
         context = dict(advertisement=qs)
     else:
         print("There are no advertisement messages to be displayed right now!")


### PR DESCRIPTION
Fixes #34.

I made a logical error when selecting the QuerySet for the advertisement/flyer tile, which caused images only to be shown on the day of their set start date, but not on any following days.

Changes proposed in this pull request:
- Changes the QuerySet of flyer images to be displayed (start date is either in the past or today AND end date is either today or in the future)
