### PR TITLE
Install stuweparser from pypi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 django
 requests
 lxml
-stuweparser==0.0.1
+stuweparser
 icalendar
 pytz

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,9 @@ setup(
     classifiers=classifiers,
     platforms='Linux',
     packages=['fachschaftsempfaenger'],
-    install_requires=load_requirements('requirements.txt')
+    install_requires=load_requirements('requirements.txt'),
+    extras_require={
+        'docs': [
+            'sphinx >= 1.4',
+            'sphinx_rtd_theme']}
 )

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,4 @@ setup(
     platforms='Linux',
     packages=['fachschaftsempfaenger'],
     install_requires=load_requirements('requirements.txt'),
-    dependency_links=[
-        # as long stuweparser is not on pypi install it from GitHub
-        'https://github.com/Trybnetic/stuweparser/archive/master.zip#egg=stuweparser-0.0.1'
-    ]
 )


### PR DESCRIPTION
Changes proposed in this pull request:
- Installs `stuweparser` from pypi instead of from github
