### PR TITLE
add recursive-include to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,8 @@ include MANIFEST.in
 include README.rst
 include LICENSE.txt
 include requirements.txt
+recursive-include fachschaftsempfaenger/static *
+recursive-include fachschaftsempfaenger/templates *
 graft fachschaftsempfaenger
 graft docs
 global-exclude __pycache__


### PR DESCRIPTION
This PR aims to fix the inclusion of all templates and static files by using `recursive-include` as proposed by the  [Django documentation](https://docs.djangoproject.com/en/2.0/intro/reusable-apps/#packaging-your-app).