### PR TITLE
Fix Mastodon tile & use posts content instead of embed

### DIFF
--- a/fachschaftsempfaenger/mastodon.py
+++ b/fachschaftsempfaenger/mastodon.py
@@ -24,7 +24,7 @@ def load_data(instance, username):
         :rtype: dict
     """
 
-    url = instance + '/users/' + username + '/outbox?min_id=0&page=true'
+    url = instance + '/users/' + username + '/outbox?page=true'
 
     request = requests.get(url)
     decoded_data = request.text.encode().decode('utf-8-sig')

--- a/fachschaftsempfaenger/templates/tiles/mastodon.html
+++ b/fachschaftsempfaenger/templates/tiles/mastodon.html
@@ -6,24 +6,42 @@
 </div>
 
 {% if toot_id %}
+
+{% comment "Alternatively use Mastodon's default embed" %}
 <iframe src="{{ toot_id }}" 
         class="mastodon-embed" 
         style="max-width: 100%; max-height=600px; border: 0;" 
         width="440" height="600"
         allowfullscreen="allowfullscreen">
 </iframe><script src="{{ toot_instance }}/embed.js" async="async"></script>
+{% endcomment %}
+
+<div class="toot" style="">
+  {% if toot_attachment %}
+    <div class="toot-gallery" style="">
+      {% for i in toot_attachment %}
+        {% if forloop.first %}
+          <img src="{{ i.url }}" alt="{{ i.name }}" style="display:block;margin-left:auto;margin-right:auto;width:80%">
+        {% endif %}
+      {% empty %}
+        <!-- No Image -->
+      {% endfor %}
+    </div>
+  {% endif %}
+
+  <div class="toot-content" style="margin:20px 10px">
+    {% if toot_content %}
+        {% autoescape off %}
+        {{ toot_content }}
+        {% endautoescape %}
+    {% else %}
+        Keine Toots verfügbar
+    {% endif %}
+  </div>
+</div>
+
 {% else %}
     Keine Toots verfügbar
 {% endif %}
-
-<!-- Maybe one day we write our own Embed...
-  {% if toot_id and toot_content %}
-      {% autoescape off %}
-      {{ toot_content }}
-      {% endautoescape %}
-  {% else %}
-      Keine Toots verfügbar
-  {% endif %}
--->
 
 {% endblock %}


### PR DESCRIPTION
Fixes wrong "latest post"

Changes proposed in this pull request:
- takes the actual last post
- refrain from using the iframe embed
