### PR TITLE
Add support for multiple calendars

### DIFF
--- a/fachschaftsempfaenger/calendar.py
+++ b/fachschaftsempfaenger/calendar.py
@@ -5,11 +5,12 @@ calendar.py
 ``calendar.py`` contains the functionality to show upcoming
 events of the student union of Computer Science in Tuebingen.
 """
-from icalendar import Calendar
+
 import requests
+from icalendar import Calendar
 
 
-def events(url):
+def events(urls):
     """
     Yields a generator of the events in the ical file provided by the url
 
@@ -21,12 +22,15 @@ def events(url):
         :rtype: generator
     """
     try:
-        response = requests.get(url, verify=False)
-        response.encoding = 'utf-8'
-        calendar = Calendar.from_ical(response.text).walk('vevent')
+        calendar = list()
+
+        for url in urls:
+            response = requests.get(url, verify=False)
+            response.encoding = "utf-8"
+            calendar = calendar + Calendar.from_ical(response.text).walk("vevent")
 
         def _key(event):
-            return event.decoded('dtstart').strftime("%Y.%m.%d %H:%M")
+            return event.decoded("dtstart").strftime("%Y.%m.%d %H:%M")
 
         calendar = sorted(calendar, key=_key, reverse=False)
 
@@ -35,21 +39,25 @@ def events(url):
         print("Connection to caldav server failed with error: ", e)
 
     def _get_date(event):
-        return event.decoded('dtstart').strftime("%d.%m.%Y")
+        return event.decoded("dtstart").strftime("%d.%m.%Y")
 
     def _get_time(event):
-        return event.decoded('dtstart').strftime("%H:%M")
+        return event.decoded("dtstart").strftime("%H:%M")
 
     def _get_title(event):
-        return event['summary']
+        return event["summary"]
 
     def _get_location(event):
         try:
-            location = event['location']
+            location = event["location"]
         except KeyError as _:
             location = "TBA"
         return location
 
     for event in calendar:
-        yield (_get_date(event), _get_time(event),
-               _get_title(event), _get_location(event))
+        yield (
+            _get_date(event),
+            _get_time(event),
+            _get_title(event),
+            _get_location(event),
+        )

--- a/fachschaftsempfaenger/views.py
+++ b/fachschaftsempfaenger/views.py
@@ -5,18 +5,15 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.shortcuts import render
 from django.utils import timezone
 
-from fachschaftsempfaenger.models import Food, Menu, Advertisement, Member, Mastodon
+from fachschaftsempfaenger.models import Advertisement, Food, Mastodon, Member, Menu
+
 from . import __author__ as author
 from . import __repository_url__ as repo_url
-from . import bus
-from . import calendar
-from . import mastodon
-from . import mensa
-from . import weather
+from . import bus, calendar, mastodon, mensa, weather
 
 
 def sitzung_tile(request):
-    ical_url = 'https://cloud.fsi.uni-tuebingen.de/remote.php/dav/public-calendars/e8wPTX4TBpCNpb7W?export'
+    ical_url = "https://cloud.fsi.uni-tuebingen.de/remote.php/dav/public-calendars/e8wPTX4TBpCNpb7W?export"
 
     """
     Naming convention for 'Sitzungen' in the FSI calender is the keyword "Sitzung" lead by either prefix {"FSI"|"FSK"}
@@ -35,7 +32,11 @@ def sitzung_tile(request):
         for event in event_generator:
             # item = (date, time, title, location)
             title = str(event[2]).lower().strip()
-            if title.endswith("sitzung") and datetime.strptime(event[0], '%d.%m.%Y').date() >= datetime.today().date():
+            if (
+                title.endswith("sitzung")
+                and datetime.strptime(event[0], "%d.%m.%Y").date()
+                >= datetime.today().date()
+            ):
                 if title.startswith("fsi") and not info:
                     info = dict(date=event[0], time=event[1], location=event[3])
                 elif title.startswith("fsk") and not kogni:
@@ -46,57 +47,64 @@ def sitzung_tile(request):
         info = None
         kogni = None
 
-    return render(request, 'tiles/sitzung.html', dict(info=info, kogni=kogni))
+    return render(request, "tiles/sitzung.html", dict(info=info, kogni=kogni))
 
 
 def calendar_tile(request):
-    ical_url = 'https://cloud.fsi.uni-tuebingen.de/remote.php/dav/public-calendars/e8wPTX4TBpCNpb7W?export'
+    ical_urls = [
+        "https://cloud.fsi.uni-tuebingen.de/remote.php/dav/public-calendars/e8wPTX4TBpCNpb7W?export",
+        "https://eei.fsi.uni-tuebingen.de/calendar.php?allevents",
+    ]
 
     number_events = 5
 
     try:
-        event_generator = calendar.events(ical_url)
+        event_generator = calendar.events(ical_urls)
         events = []
         for item in event_generator:
             # only put the item in if it is today or in the future
-            if datetime.strptime(item[0], '%d.%m.%Y').date() >= datetime.today().date():
+            if datetime.strptime(item[0], "%d.%m.%Y").date() >= datetime.today().date():
                 events.append(item)
         # slice according to number_events
         events = events[:number_events]
     except:
-        event_generator = calendar.events(ical_url)
+        event_generator = calendar.events(ical_urls)
         events = list(event_generator)  # [:number_events]
 
     url = "https://cloud.fsi.uni-tuebingen.de/apps/calendar/p/e8wPTX4TBpCNpb7W"
     events = events[:number_events]
 
-    return render(request, 'tiles/calendar.html', dict(events=events, link=url))
+    return render(request, "tiles/calendar.html", dict(events=events, link=url))
 
 
 def bus_tile(request):
-    stopid = 'de:08416:10252:0:4'
-    url = 'https://www.swtue.de/abfahrt.html?halt={}'.format(stopid)
+    stopid = "de:08416:10252:0:4"
+    url = "https://www.swtue.de/abfahrt.html?halt={}".format(stopid)
     events = bus.get_departures(stopid)
 
-    return render(request, 'tiles/bus.html', dict(events=events, link=url))
+    return render(request, "tiles/bus.html", dict(events=events, link=url))
 
 
 def forecast_tile(request):
     import urllib.request
-    response = urllib.request.urlopen(
-        'http://api.openweathermap.org/data/2.5/forecast?q=Tuebingen,DE&appid=806b3582a0c4787e47e950a6274b681a&units=metric')
-    content = response.read()
-    data = json.loads(content.decode('utf-8'))
 
-    today_string = datetime.datetime.now().strftime('%Y-%m-%d')
-    tomorrow_string = (datetime.datetime.now() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')
+    response = urllib.request.urlopen(
+        "http://api.openweathermap.org/data/2.5/forecast?q=Tuebingen,DE&appid=806b3582a0c4787e47e950a6274b681a&units=metric"
+    )
+    content = response.read()
+    data = json.loads(content.decode("utf-8"))
+
+    today_string = datetime.datetime.now().strftime("%Y-%m-%d")
+    tomorrow_string = (datetime.datetime.now() + datetime.timedelta(days=1)).strftime(
+        "%Y-%m-%d"
+    )
 
     days = dict()
-    for d in data['list']:
-        tmp_day = d['dt_txt'][:10]
+    for d in data["list"]:
+        tmp_day = d["dt_txt"][:10]
         if not (tmp_day == today_string or tmp_day == tomorrow_string):
             continue
-        if ' 09:00' in d['dt_txt'] or ' 12:00' in d['dt_txt'] or '18:00' in d['dt_txt']:
+        if " 09:00" in d["dt_txt"] or " 12:00" in d["dt_txt"] or "18:00" in d["dt_txt"]:
             if tmp_day in days:
                 days[tmp_day].append(d)
             else:
@@ -106,13 +114,15 @@ def forecast_tile(request):
     else:
         days_array = [days[tomorrow_string]]
 
-    return render(request, 'tiles/forecast.html', dict(data=days, data_array=days_array))
+    return render(
+        request, "tiles/forecast.html", dict(data=days, data_array=days_array)
+    )
 
 
 def weather_tile(request, use_kelvin=False):
     ctx = weather.weather_data()
-    ctx['link'] = 'https://wetteronline.de/wetter-aktuell/tuebingen'
-    return render(request, 'tiles/weather.html', ctx)
+    ctx["link"] = "https://wetteronline.de/wetter-aktuell/tuebingen"
+    return render(request, "tiles/weather.html", ctx)
 
 
 def mensa_tile(request, mensa_name: str):
@@ -120,23 +130,25 @@ def mensa_tile(request, mensa_name: str):
         "morgenstelle": {
             "id": "621",
             "path": "mensa-morgenstelle-tuebingen",
-            "name": "Morgenstelle"
+            "name": "Morgenstelle",
         },
         "wilhelmstraße": {
             "id": "611",
             "path": "mensa-wilhelmstrasse-tuebingen",
-            "name": "Wilhelmstraße"
+            "name": "Wilhelmstraße",
         },
         "prinz_karl": {
             "id": "611",
             "path": "mensa-prinz-karl-tuebingen",
-            "name": "Prinz Karl"
-        }
+            "name": "Prinz Karl",
+        },
     }
     mensa_data = mensa_name_id_map.get(mensa_name, mensa_name)
     mensa_id = mensa_data["id"]
     mensa_website = "https://www.my-stuwe.de/mensa/{}".format(mensa_data["path"])
-    mensa_json = "https://www.my-stuwe.de/wp-json/mealplans/v1/canteens/{}".format(mensa_id)
+    mensa_json = "https://www.my-stuwe.de/wp-json/mealplans/v1/canteens/{}".format(
+        mensa_id
+    )
 
     try:
         date_string, meals = mensa.load_data(mensa_json, mensa_id)
@@ -145,7 +157,7 @@ def mensa_tile(request, mensa_name: str):
             "meals": meals,
             "link": mensa_website,
             "date": date_string,
-            "name": mensa_data["name"]
+            "name": mensa_data["name"],
         }
     except BaseException as e:
         print("Error retrieving the Mensa plan!", e)
@@ -153,10 +165,10 @@ def mensa_tile(request, mensa_name: str):
             "meals": None,
             "link": mensa_website,
             "date": None,
-            "name": mensa_data["name"]
+            "name": mensa_data["name"],
         }
 
-    return render(request, 'tiles/mensa.html', context)
+    return render(request, "tiles/mensa.html", context)
 
 
 def mastodon_tile(request):
@@ -185,18 +197,26 @@ def mastodon_tile(request):
     try:
         toot_id, toot_content, toot_attachment = mastodon.load_data(instance, username)
 
-        context = dict(toot_id=toot_id.replace('activity', 'embed'),
-                       toot_content=toot_content,
-                       toot_attachment=toot_attachment,
-                       toot_instance=instance,
-                       link=profile)
+        context = dict(
+            toot_id=toot_id.replace("activity", "embed"),
+            toot_content=toot_content,
+            toot_attachment=toot_attachment,
+            toot_instance=instance,
+            link=profile,
+        )
 
     except BaseException as e:
         print("Error retrieving the mastodon toot!", e)
-        context = dict(toot_id=None, toot_content=None, toot_attachment=None,
-                       toot_instance=instance, link=profile, hidden=True)
+        context = dict(
+            toot_id=None,
+            toot_content=None,
+            toot_attachment=None,
+            toot_instance=instance,
+            link=profile,
+            hidden=True,
+        )
 
-    return render(request, 'tiles/mastodon.html', context)
+    return render(request, "tiles/mastodon.html", context)
 
 
 def foodtruck_tile(request):
@@ -206,17 +226,21 @@ def foodtruck_tile(request):
     If no menu exists for this time period, an exception is thrown and and a `None` object is passed to the template.
     """
     try:
-        menu_date = Menu.objects.get(date__gte=timezone.now(),
-                                     date__lte=timezone.now() + datetime.timedelta(days=6)).date.strftime("%d.%m.%Y")
-        menu = Food.objects.filter(menu_item__date__gte=timezone.now(),
-                                   menu_item__date__lte=timezone.now() + datetime.timedelta(days=6))
+        menu_date = Menu.objects.get(
+            date__gte=timezone.now(),
+            date__lte=timezone.now() + datetime.timedelta(days=6),
+        ).date.strftime("%d.%m.%Y")
+        menu = Food.objects.filter(
+            menu_item__date__gte=timezone.now(),
+            menu_item__date__lte=timezone.now() + datetime.timedelta(days=6),
+        )
 
         context = dict(menu=menu, menu_date=menu_date)
     except ObjectDoesNotExist:
         print("No appropriate food truck items or menus found for the current week!")
         context = dict(menu=None, hidden=True)
 
-    return render(request, 'tiles/foodtruck.html', context)
+    return render(request, "tiles/foodtruck.html", context)
 
 
 def advertisement_tile(request):
@@ -226,18 +250,21 @@ def advertisement_tile(request):
     # Are there any messages to be displayed right now? If there are, select one at random.
     # Note that this query is quite expensive and could potentially slow the load time of this tile down.
     if Advertisement.objects.filter(
-            start_date__lte=timezone.now(),
-            end_date__gte=timezone.now()
+        start_date__lte=timezone.now(), end_date__gte=timezone.now()
     ):
-        qs = Advertisement.objects.filter(
-            start_date__lte=timezone.now(),
-            end_date__gte=timezone.now()).order_by('?').first()
+        qs = (
+            Advertisement.objects.filter(
+                start_date__lte=timezone.now(), end_date__gte=timezone.now()
+            )
+            .order_by("?")
+            .first()
+        )
         context = dict(advertisement=qs)
     else:
         print("There are no advertisement messages to be displayed right now!")
         context = dict(advertisement=None, hidden=True)
 
-    return render(request, 'tiles/advertisement.html', context)
+    return render(request, "tiles/advertisement.html", context)
 
 
 def fachschaft_tile(request):
@@ -248,13 +275,13 @@ def fachschaft_tile(request):
     # Select one of the people in the database at random and display their details.
     # Note that this query is quite expensive and could potentially slow the load time of this tile down.
     if Member.objects.exists():
-        qs = Member.objects.order_by('?').first()
+        qs = Member.objects.order_by("?").first()
         context = dict(person=qs)
     else:
         print("No people of the student union found in database!")
         context = dict(person=None, hidden=True)
 
-    return render(request, 'tiles/fachschaft.html', context)
+    return render(request, "tiles/fachschaft.html", context)
 
 
 def index(request):
@@ -262,8 +289,8 @@ def index(request):
     The tiles that are displayed on the main page are loaded via JQuery (see index.html file itself)
     Additional data to be displayed (i.e. footer, overlays etc.) can be passed via the context.
     """
-    copy = '2018 ' + author
+    copy = "2018 " + author
 
     context = dict(author=author, copyright=copy, repo_url=repo_url)
 
-    return render(request, 'index.html', context)
+    return render(request, "index.html", context)


### PR DESCRIPTION
As the EEI now exports all ersti events they are no longer included in the main fsi calendar and thus the Fachschaftsempfänger has a need to support multiple calendars.

This PR introduces that.

(I used a formatter the main changes are in lines 25 of `calendar.py` and the additional link in `views.py`)